### PR TITLE
置き換え後にうまく翻訳できないバグの修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -131,9 +131,6 @@ function replaceCodeTagsForNode(node) {
     if (existingSpan && existingSpan.tagName.toLowerCase() === "span") {
       const { newElem } = processCodeTag(node);
 
-      // spanノードをインラインに設定する
-      newElem.style.display = "inline";
-
       parent.replaceChild(newElem, existingSpan);
       applyVisualStylesSafely(newElem, spanStyle);
     }


### PR DESCRIPTION
#2 
不要なdisplay: inline属性の付与する処理を削除しました。