### PR TITLE
notranslateクラスによる翻訳バグの修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -71,7 +71,9 @@ function processCodeTag(node) {
     newElem.appendChild(node.firstChild);
   }
   Array.from(node.attributes).forEach((attr) => {
-    newElem.setAttribute(attr.name, attr.value);
+    if (attr.name !== "class" || !attr.value.includes("notranslate")) {
+      newElem.setAttribute(attr.name, attr.value);
+    }
   });
   newElem.style.cssText = styleCssText;
 


### PR DESCRIPTION
#2 
# 現象
元のcode要素にnotranslateクラスが付与されている場合に、置き換え後のspan要素がそれを引き継ぎ、
翻訳が不自然になる問題を発見しました。

# 対処
置き換え後のspan要素にnotranslateクラスを引き継がないように変更しました。